### PR TITLE
Adding /api endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ var bodyParser = require('body-parser');
 var swig = require('swig');
 
 var routes = require('./routes/index');
-var users = require('./routes/users');
+var api = require('./routes/api');
 
 var app = express();
 
@@ -35,7 +35,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', routes);
-app.use('/users', users);
+app.use('/api', api);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,0 +1,8 @@
+var express = require('express');
+var router = express.Router();
+
+router.get('/', function(request, response, next) {
+    response.json({name: 'name'})
+});
+
+module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;


### PR DESCRIPTION
The system needs to have a PREST endpoint: `/api`.

This PR adds a route that is called for all `/api` calls
